### PR TITLE
Add request parsing exception and server exception handling

### DIFF
--- a/src/main/java/scarvill/httpserver/request/HttpRequest.java
+++ b/src/main/java/scarvill/httpserver/request/HttpRequest.java
@@ -20,7 +20,7 @@ public class HttpRequest {
         this.requestLineAndHeaders = requestLineAndHeaders;
     }
 
-    public Request parse() throws IllFormedRequest {
+    public Request parse() {
         return new RequestBuilder()
             .setMethod(parseMethod())
             .setURI(parseURI())
@@ -30,7 +30,7 @@ public class HttpRequest {
             .build();
     }
 
-    private Method parseMethod() throws IllFormedRequest {
+    private Method parseMethod() {
         String method = requestLineAndHeaders.split(" ")[0];
         switch (method) {
             case "GET":
@@ -48,7 +48,7 @@ public class HttpRequest {
             case "DELETE":
                 return DELETE;
             default:
-                throw new IllFormedRequest("Cannot parse ill-formed HTTP request: Invalid method.");
+                return UNSUPPORTED;
         }
     }
 
@@ -56,14 +56,13 @@ public class HttpRequest {
         return requestLineAndHeaders.split(" ")[1].split("\\?")[0];
     }
 
-    private HashMap<String, String> parseParameters() throws IllFormedRequest {
+    private HashMap<String, String> parseParameters() {
         HashMap<String, String> parameters = new HashMap<>();
 
         if (requestHasQueryString()) {
             try {
                 parameters = parseQueryStringParameters(requestLineAndHeaders.split(" ")[1].split("\\?")[1]);
-            } catch (UnsupportedEncodingException e) {
-                throw new IllFormedRequest("Cannot parse ill-formed HTTP request: Invalid URI character encoding.");
+            } catch (UnsupportedEncodingException ignored) {
             }
         }
 
@@ -114,11 +113,5 @@ public class HttpRequest {
 
     private boolean includesHeaders(String[] requestLines) {
         return requestLines.length > 2;
-    }
-
-    public class IllFormedRequest extends Exception {
-        public IllFormedRequest(String message) {
-            super(message);
-        }
     }
 }

--- a/src/main/java/scarvill/httpserver/request/HttpRequest.java
+++ b/src/main/java/scarvill/httpserver/request/HttpRequest.java
@@ -48,7 +48,7 @@ public class HttpRequest {
             case "DELETE":
                 return DELETE;
             default:
-                return NULL_METHOD;
+                return null;
         }
     }
 

--- a/src/main/java/scarvill/httpserver/request/Method.java
+++ b/src/main/java/scarvill/httpserver/request/Method.java
@@ -1,22 +1,5 @@
 package scarvill.httpserver.request;
 
 public enum Method {
-    GET("GET"),
-    HEAD("HEAD"),
-    OPTIONS("OPTIONS"),
-    PUT("PUT"),
-    POST("POST"),
-    DELETE("DELETE"),
-    PATCH("PATCH"),
-    NULL_METHOD("UNRECOGNIZED_METHOD");
-
-    private final String methodString;
-
-    Method(String methodString) {
-        this.methodString = methodString;
-    }
-
-    public String toString() {
-        return this.methodString;
-    }
+    GET, HEAD, OPTIONS, PUT, POST, DELETE, PATCH
 }

--- a/src/main/java/scarvill/httpserver/request/Method.java
+++ b/src/main/java/scarvill/httpserver/request/Method.java
@@ -1,5 +1,5 @@
 package scarvill.httpserver.request;
 
 public enum Method {
-    GET, HEAD, OPTIONS, PUT, POST, DELETE, PATCH
+    GET, HEAD, OPTIONS, PUT, POST, DELETE, PATCH, UNSUPPORTED
 }

--- a/src/main/java/scarvill/httpserver/response/Status.java
+++ b/src/main/java/scarvill/httpserver/response/Status.java
@@ -2,12 +2,13 @@ package scarvill.httpserver.response;
 
 public enum Status {
     OK("200 OK"),
-    NOT_FOUND("404 Not Found"),
-    METHOD_NOT_ALLOWED("405 Method Not Allowed"),
-    FOUND("302 Found"),
+    NO_CONTENT("204 No Content"),
     PARTIAL_CONTENT("206 Partial Content"),
+    FOUND("302 Found"),
+    BAD_REQUEST("400 Bad Request"),
     UNAUTHORIZED("401 Unauthorized"),
-    NO_CONTENT("204 No Content");
+    NOT_FOUND("404 Not Found"),
+    METHOD_NOT_ALLOWED("405 Method Not Allowed");
 
     private final String statusString;
 

--- a/src/main/java/scarvill/httpserver/response/Status.java
+++ b/src/main/java/scarvill/httpserver/response/Status.java
@@ -8,7 +8,8 @@ public enum Status {
     BAD_REQUEST("400 Bad Request"),
     UNAUTHORIZED("401 Unauthorized"),
     NOT_FOUND("404 Not Found"),
-    METHOD_NOT_ALLOWED("405 Method Not Allowed");
+    METHOD_NOT_ALLOWED("405 Method Not Allowed"),
+    SERVER_ERROR("500 Internal Server Error");
 
     private final String statusString;
 

--- a/src/main/java/scarvill/httpserver/response/Status.java
+++ b/src/main/java/scarvill/httpserver/response/Status.java
@@ -5,7 +5,6 @@ public enum Status {
     NO_CONTENT("204 No Content"),
     PARTIAL_CONTENT("206 Partial Content"),
     FOUND("302 Found"),
-    BAD_REQUEST("400 Bad Request"),
     UNAUTHORIZED("401 Unauthorized"),
     NOT_FOUND("404 Not Found"),
     METHOD_NOT_ALLOWED("405 Method Not Allowed"),

--- a/src/main/java/scarvill/httpserver/server/HttpService.java
+++ b/src/main/java/scarvill/httpserver/server/HttpService.java
@@ -39,20 +39,26 @@ public class HttpService implements Serveable {
     }
 
     private void handleClientTransaction(BufferedReader in, BufferedOutputStream out) throws IOException {
-        Response response;
+        Response response = generateResponse(in);
+        logger.logResponse(response);
+        io.writeResponse(out, response);
+    }
+
+    private Response generateResponse(BufferedReader in) {
         try {
             Request request = io.readRequest(in);
             logger.logRequest(request);
-            response = router.apply(request);
+
+            return router.apply(request);
         } catch (HttpRequest.IllFormedRequest e) {
             logger.logException(e.getMessage());
-            response = badRequestResponse(e.getMessage());
+
+            return badRequestResponse(e.getMessage());
         } catch (IOException e) {
             logger.logException(e.getMessage());
-            response = serverErrorResponse();
+
+            return serverErrorResponse();
         }
-        logger.logResponse(response);
-        io.writeResponse(out, response);
     }
 
     private Response badRequestResponse(String message) {

--- a/src/main/java/scarvill/httpserver/server/HttpService.java
+++ b/src/main/java/scarvill/httpserver/server/HttpService.java
@@ -11,7 +11,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Socket;
-import java.text.ParseException;
 import java.util.function.Function;
 
 public class HttpService implements Serveable {

--- a/src/main/java/scarvill/httpserver/server/HttpService.java
+++ b/src/main/java/scarvill/httpserver/server/HttpService.java
@@ -1,5 +1,6 @@
 package scarvill.httpserver.server;
 
+import scarvill.httpserver.request.HttpRequest;
 import scarvill.httpserver.request.Request;
 import scarvill.httpserver.response.Response;
 
@@ -8,6 +9,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Socket;
+import java.text.ParseException;
 import java.util.function.Function;
 
 public class HttpService implements Serveable {
@@ -36,7 +38,12 @@ public class HttpService implements Serveable {
     }
 
     private void handleClientTransaction(BufferedReader in, BufferedOutputStream out) throws IOException {
-        Request request = io.readRequest(in);
+        Request request = null;
+        try {
+            request = io.readRequest(in);
+        } catch (HttpRequest.IllFormedRequest e) {
+            e.printStackTrace();
+        }
         Response response = router.apply(request);
         io.writeResponse(out, response);
         logTransaction(request, response);

--- a/src/main/java/scarvill/httpserver/server/HttpService.java
+++ b/src/main/java/scarvill/httpserver/server/HttpService.java
@@ -3,6 +3,8 @@ package scarvill.httpserver.server;
 import scarvill.httpserver.request.HttpRequest;
 import scarvill.httpserver.request.Request;
 import scarvill.httpserver.response.Response;
+import scarvill.httpserver.response.ResponseBuilder;
+import scarvill.httpserver.response.Status;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
@@ -38,19 +40,22 @@ public class HttpService implements Serveable {
     }
 
     private void handleClientTransaction(BufferedReader in, BufferedOutputStream out) throws IOException {
-        Request request = null;
+        Response response;
         try {
-            request = io.readRequest(in);
+            Request request = io.readRequest(in);
+            response = router.apply(request);
+            logger.logRequest(request);
         } catch (HttpRequest.IllFormedRequest e) {
-            e.printStackTrace();
+            response = badRequestResponse(e.getMessage());
         }
-        Response response = router.apply(request);
+        logger.logResponse(response);
         io.writeResponse(out, response);
-        logTransaction(request, response);
     }
 
-    private void logTransaction(Request request, Response response) {
-        logger.logRequest(request);
-        logger.logResponse(response);
+    private Response badRequestResponse(String message) {
+        return new ResponseBuilder()
+            .setStatus(Status.BAD_REQUEST)
+            .setBody(message.getBytes())
+            .build();
     }
 }

--- a/src/main/java/scarvill/httpserver/server/HttpService.java
+++ b/src/main/java/scarvill/httpserver/server/HttpService.java
@@ -43,9 +43,10 @@ public class HttpService implements Serveable {
         Response response;
         try {
             Request request = io.readRequest(in);
-            response = router.apply(request);
             logger.logRequest(request);
+            response = router.apply(request);
         } catch (HttpRequest.IllFormedRequest e) {
+            logger.logException(e.getMessage());
             response = badRequestResponse(e.getMessage());
         }
         logger.logResponse(response);

--- a/src/main/java/scarvill/httpserver/server/HttpService.java
+++ b/src/main/java/scarvill/httpserver/server/HttpService.java
@@ -50,22 +50,11 @@ public class HttpService implements Serveable {
             logger.logRequest(request);
 
             return router.apply(request);
-        } catch (HttpRequest.IllFormedRequest e) {
-            logger.logException(e.getMessage());
-
-            return badRequestResponse(e.getMessage());
         } catch (IOException e) {
             logger.logException(e.getMessage());
 
             return serverErrorResponse();
         }
-    }
-
-    private Response badRequestResponse(String message) {
-        return new ResponseBuilder()
-            .setStatus(Status.BAD_REQUEST)
-            .setBody((Status.BAD_REQUEST.toString() + "\n" + message).getBytes())
-            .build();
     }
 
     private Response serverErrorResponse() {

--- a/src/main/java/scarvill/httpserver/server/HttpService.java
+++ b/src/main/java/scarvill/httpserver/server/HttpService.java
@@ -48,6 +48,9 @@ public class HttpService implements Serveable {
         } catch (HttpRequest.IllFormedRequest e) {
             logger.logException(e.getMessage());
             response = badRequestResponse(e.getMessage());
+        } catch (IOException e) {
+            logger.logException(e.getMessage());
+            response = serverErrorResponse();
         }
         logger.logResponse(response);
         io.writeResponse(out, response);
@@ -56,7 +59,14 @@ public class HttpService implements Serveable {
     private Response badRequestResponse(String message) {
         return new ResponseBuilder()
             .setStatus(Status.BAD_REQUEST)
-            .setBody(message.getBytes())
+            .setBody((Status.BAD_REQUEST.toString() + "\n" + message).getBytes())
+            .build();
+    }
+
+    private Response serverErrorResponse() {
+        return new ResponseBuilder()
+            .setStatus(Status.SERVER_ERROR)
+            .setBody(Status.SERVER_ERROR.toString().getBytes())
             .build();
     }
 }

--- a/src/main/java/scarvill/httpserver/server/Logger.java
+++ b/src/main/java/scarvill/httpserver/server/Logger.java
@@ -34,4 +34,9 @@ public class Logger {
         out.println("Body-length: " + response.getBody().length);
         out.println();
     }
+
+    public void logException(String message) {
+        out.println("*** Server Exception ***");
+        out.println(message);
+    }
 }

--- a/src/main/java/scarvill/httpserver/server/ServerIO.java
+++ b/src/main/java/scarvill/httpserver/server/ServerIO.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public class ServerIO {
-    public Request readRequest(BufferedReader in) throws IOException {
+    public Request readRequest(BufferedReader in) throws IOException, HttpRequest.IllFormedRequest {
         String requestLineAndHeaders = readRequestLineAndHeaders(in);
         byte[] body = readBody(in);
 

--- a/src/main/java/scarvill/httpserver/server/ServerIO.java
+++ b/src/main/java/scarvill/httpserver/server/ServerIO.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public class ServerIO {
-    public Request readRequest(BufferedReader in) throws IOException, HttpRequest.IllFormedRequest {
+    public Request readRequest(BufferedReader in) throws IOException {
         String requestLineAndHeaders = readRequestLineAndHeaders(in);
         byte[] body = readBody(in);
 

--- a/src/test/java/scarvill/httpserver/request/HttpRequestTest.java
+++ b/src/test/java/scarvill/httpserver/request/HttpRequestTest.java
@@ -8,7 +8,7 @@ import static scarvill.httpserver.request.Method.*;
 
 public class HttpRequestTest {
     @Test
-    public void testParsesRequestMethod() throws HttpRequest.IllFormedRequest {
+    public void testParsesRequestMethod()  {
         Request getRequest = new HttpRequest(GET.toString() + " /uri HTTP/1.1\r\n\r\n").parse();
         Request postRequest = new HttpRequest(POST.toString() + " /uri HTTP/1.1\r\n\r\n").parse();
         Request putRequest = new HttpRequest(PUT.toString() + " /uri HTTP/1.1\r\n\r\n").parse();
@@ -26,20 +26,22 @@ public class HttpRequestTest {
         assertEquals(HEAD, headRequest.getMethod());
     }
 
-    @Test(expected = HttpRequest.IllFormedRequest.class)
-    public void testThrowsIllFormedRequestWhenGivenRawHTTPRequestWithInvalidMethod() throws HttpRequest.IllFormedRequest {
-        new HttpRequest("FOO /uri HTTP/1.1\r\n\r\n").parse();
+    @Test
+    public void testParsesUnsupportedMethodInRawHTTPRequest() {
+        Request request = new HttpRequest("FOO /uri HTTP/1.1\r\n\r\n").parse();
+
+        assertEquals(Method.UNSUPPORTED, request.getMethod());
     }
 
     @Test
-    public void testParsesRawHTTPRequestURI() throws HttpRequest.IllFormedRequest {
+    public void testParsesRawHTTPRequestURI()  {
         Request request = new HttpRequest("GET /uri HTTP/1.1\r\n\r\n").parse();
 
         assertEquals("/uri", request.getURI());
     }
 
     @Test
-    public void testParsesRawHTTPRequestWithQueryStringParameters() throws HttpRequest.IllFormedRequest {
+    public void testParsesRawHTTPRequestWithQueryStringParameters() {
         Request request = new HttpRequest("GET /uri?foo=bar&bar=baz HTTP/1.1\r\n\r\n").parse();
 
         assertEquals("/uri", request.getURI());
@@ -48,7 +50,7 @@ public class HttpRequestTest {
     }
 
     @Test
-    public void testIgnoresNonParameterQueryStringElements() throws HttpRequest.IllFormedRequest {
+    public void testIgnoresNonParameterQueryStringElements() {
         Request request = new HttpRequest("GET /uri?ignored&bar=baz HTTP/1.1\r\n\r\n").parse();
 
         assertEquals("/uri", request.getURI());
@@ -56,7 +58,7 @@ public class HttpRequestTest {
     }
 
     @Test
-    public void testTranslatesSpecialCharacterCodesInQueryString() throws HttpRequest.IllFormedRequest {
+    public void testTranslatesSpecialCharacterCodesInQueryString() {
         String query = "message=%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26" +
             "%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F";
         String translatedMessage =
@@ -68,7 +70,7 @@ public class HttpRequestTest {
     }
 
     @Test
-    public void testParsesRawHTTPRequestHeaders() throws HttpRequest.IllFormedRequest {
+    public void testParsesRawHTTPRequestHeaders() {
         String rawRequest = "GET /uri HTTP/1.1\r\n" +
             "Header: a header\r\n" +
             "Other: other header\r\n" +
@@ -80,14 +82,14 @@ public class HttpRequestTest {
     }
 
     @Test
-    public void testParsesRawHTTPRequestWithNoBody() throws HttpRequest.IllFormedRequest {
+    public void testParsesRawHTTPRequestWithNoBody() {
         Request request = new HttpRequest("GET /uri HTTP/1.1\r\n\r\n").parse();
 
         assertArrayEquals(new byte[]{}, request.getBody());
     }
 
     @Test
-    public void testParsesRawHTTPRequestWithBody() throws HttpRequest.IllFormedRequest {
+    public void testParsesRawHTTPRequestWithBody() {
         Request request = new HttpRequest("GET /uri HTTP/1.1\r\n\r\n", "body".getBytes()).parse();
 
         assertArrayEquals("body".getBytes(), request.getBody());

--- a/src/test/java/scarvill/httpserver/request/HttpRequestTest.java
+++ b/src/test/java/scarvill/httpserver/request/HttpRequestTest.java
@@ -8,7 +8,7 @@ import static scarvill.httpserver.request.Method.*;
 
 public class HttpRequestTest {
     @Test
-    public void testParsesRequestMethod() {
+    public void testParsesRequestMethod() throws HttpRequest.IllFormedRequest {
         Request getRequest = new HttpRequest(GET.toString() + " /uri HTTP/1.1\r\n\r\n").parse();
         Request postRequest = new HttpRequest(POST.toString() + " /uri HTTP/1.1\r\n\r\n").parse();
         Request putRequest = new HttpRequest(PUT.toString() + " /uri HTTP/1.1\r\n\r\n").parse();
@@ -26,22 +26,20 @@ public class HttpRequestTest {
         assertEquals(HEAD, headRequest.getMethod());
     }
 
-    @Test
-    public void testParsesInvalidRawHTTPRequestMethod() {
-        Request request = new HttpRequest("FOO /uri HTTP/1.1\r\n\r\n").parse();
-
-        assertEquals(null, request.getMethod());
+    @Test(expected = HttpRequest.IllFormedRequest.class)
+    public void testThrowsIllFormedRequestWhenGivenRawHTTPRequestWithInvalidMethod() throws HttpRequest.IllFormedRequest {
+        new HttpRequest("FOO /uri HTTP/1.1\r\n\r\n").parse();
     }
 
     @Test
-    public void testParsesRawHTTPRequestURI() {
+    public void testParsesRawHTTPRequestURI() throws HttpRequest.IllFormedRequest {
         Request request = new HttpRequest("GET /uri HTTP/1.1\r\n\r\n").parse();
 
         assertEquals("/uri", request.getURI());
     }
 
     @Test
-    public void testParsesRawHTTPRequestWithQueryStringParameters() {
+    public void testParsesRawHTTPRequestWithQueryStringParameters() throws HttpRequest.IllFormedRequest {
         Request request = new HttpRequest("GET /uri?foo=bar&bar=baz HTTP/1.1\r\n\r\n").parse();
 
         assertEquals("/uri", request.getURI());
@@ -50,7 +48,7 @@ public class HttpRequestTest {
     }
 
     @Test
-    public void testIgnoresNonParameterQueryStringElements() {
+    public void testIgnoresNonParameterQueryStringElements() throws HttpRequest.IllFormedRequest {
         Request request = new HttpRequest("GET /uri?ignored&bar=baz HTTP/1.1\r\n\r\n").parse();
 
         assertEquals("/uri", request.getURI());
@@ -58,7 +56,7 @@ public class HttpRequestTest {
     }
 
     @Test
-    public void testTranslatesSpecialCharacterCodesInQueryString() {
+    public void testTranslatesSpecialCharacterCodesInQueryString() throws HttpRequest.IllFormedRequest {
         String query = "message=%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26" +
             "%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F";
         String translatedMessage =
@@ -70,7 +68,7 @@ public class HttpRequestTest {
     }
 
     @Test
-    public void testParsesRawHTTPRequestHeaders() {
+    public void testParsesRawHTTPRequestHeaders() throws HttpRequest.IllFormedRequest {
         String rawRequest = "GET /uri HTTP/1.1\r\n" +
             "Header: a header\r\n" +
             "Other: other header\r\n" +
@@ -82,14 +80,14 @@ public class HttpRequestTest {
     }
 
     @Test
-    public void testParsesRawHTTPRequestWithNoBody() {
+    public void testParsesRawHTTPRequestWithNoBody() throws HttpRequest.IllFormedRequest {
         Request request = new HttpRequest("GET /uri HTTP/1.1\r\n\r\n").parse();
 
         assertArrayEquals(new byte[]{}, request.getBody());
     }
 
     @Test
-    public void testParsesRawHTTPRequestWithBody() {
+    public void testParsesRawHTTPRequestWithBody() throws HttpRequest.IllFormedRequest {
         Request request = new HttpRequest("GET /uri HTTP/1.1\r\n\r\n", "body".getBytes()).parse();
 
         assertArrayEquals("body".getBytes(), request.getBody());

--- a/src/test/java/scarvill/httpserver/request/HttpRequestTest.java
+++ b/src/test/java/scarvill/httpserver/request/HttpRequestTest.java
@@ -30,7 +30,7 @@ public class HttpRequestTest {
     public void testParsesInvalidRawHTTPRequestMethod() {
         Request request = new HttpRequest("FOO /uri HTTP/1.1\r\n\r\n").parse();
 
-        assertEquals(NULL_METHOD, request.getMethod());
+        assertEquals(null, request.getMethod());
     }
 
     @Test

--- a/src/test/java/scarvill/httpserver/server/HttpServiceTest.java
+++ b/src/test/java/scarvill/httpserver/server/HttpServiceTest.java
@@ -52,20 +52,6 @@ public class HttpServiceTest {
     }
 
     @Test
-    public void testSends400BadRequestResponseWhenReceivesIllFormedRequest() throws Exception {
-        byte[] rawRequest = "FOO / HTTP/1.1\r\n\r\n".getBytes();
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawRequest);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        MockSocket clientSocket = new MockSocket(inputStream, outputStream);
-        Logger logger = new Logger(new NullPrintStream());
-        HttpService service = new HttpService(logger, new RouteRequest());
-
-        service.serve(clientSocket).run();
-
-        assertTrue(new String(outputStream.toByteArray()).contains(Status.BAD_REQUEST.toString()));
-    }
-
-    @Test
     public void testSends500ServerErrorResponseWhenAnIOExceptionIsRaised() throws Exception {
         InputStream inputStream = new FailingInputStream();
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/src/test/java/scarvill/httpserver/server/HttpServiceTest.java
+++ b/src/test/java/scarvill/httpserver/server/HttpServiceTest.java
@@ -6,6 +6,7 @@ import scarvill.httpserver.response.Response;
 import scarvill.httpserver.response.ResponseBuilder;
 import scarvill.httpserver.response.Status;
 import scarvill.httpserver.routing.GiveStaticResponse;
+import scarvill.httpserver.routing.RouteRequest;
 
 import java.io.*;
 import java.net.Socket;
@@ -48,6 +49,20 @@ public class HttpServiceTest {
         service.serve(clientSocket).run();
 
         assertEquals(expectedResponseString, new String(outputStream.toByteArray()));
+    }
+
+    @Test
+    public void testSends400BadResponseWhenReceivesIllFormedRequest() throws Exception {
+        byte[] rawRequest = "FOO / HTTP/1.1\r\n\r\n".getBytes();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawRequest);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        MockSocket clientSocket = new MockSocket(inputStream, outputStream);
+        Logger logger = new Logger(new NullPrintStream());
+        HttpService service = new HttpService(logger, new RouteRequest());
+
+        service.serve(clientSocket).run();
+
+        assertTrue(new String(outputStream.toByteArray()).contains(Status.BAD_REQUEST.toString()));
     }
 
     private class MockSocket extends Socket {

--- a/src/test/java/scarvill/httpserver/server/LoggerTest.java
+++ b/src/test/java/scarvill/httpserver/server/LoggerTest.java
@@ -67,4 +67,18 @@ public class LoggerTest {
 
         assertEquals(expectedLog, out.toString());
     }
+
+    @Test
+    public void testLogsExceptionMessageToGivenOutputStream() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Logger logger = new Logger(new PrintStream(out));
+
+        String expectedLog =
+            "*** Server Exception ***\n" +
+                "exception message\n";
+
+        logger.logException("exception message");
+
+        assertEquals(expectedLog, out.toString());
+    }
 }

--- a/src/test/java/scarvill/httpserver/server/ServerIOTest.java
+++ b/src/test/java/scarvill/httpserver/server/ServerIOTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 
 public class ServerIOTest {
     @Test
-    public void testReadsRequestFromStream() throws IOException, HttpRequest.IllFormedRequest {
+    public void testReadsRequestFromStream() throws IOException {
         byte[] rawRequest = "GET / HTTP/1.1\r\n\r\n".getBytes();
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawRequest);
         BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));

--- a/src/test/java/scarvill/httpserver/server/ServerIOTest.java
+++ b/src/test/java/scarvill/httpserver/server/ServerIOTest.java
@@ -10,7 +10,6 @@ import scarvill.httpserver.response.ResponseBuilder;
 import scarvill.httpserver.response.Status;
 
 import java.io.*;
-import java.text.ParseException;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/scarvill/httpserver/server/ServerIOTest.java
+++ b/src/test/java/scarvill/httpserver/server/ServerIOTest.java
@@ -1,6 +1,7 @@
 package scarvill.httpserver.server;
 
 import org.junit.Test;
+import scarvill.httpserver.request.HttpRequest;
 import scarvill.httpserver.request.Method;
 import scarvill.httpserver.request.Request;
 import scarvill.httpserver.response.HttpResponse;
@@ -9,12 +10,13 @@ import scarvill.httpserver.response.ResponseBuilder;
 import scarvill.httpserver.response.Status;
 
 import java.io.*;
+import java.text.ParseException;
 
 import static org.junit.Assert.assertEquals;
 
 public class ServerIOTest {
     @Test
-    public void testReadsRequestFromStream() throws IOException {
+    public void testReadsRequestFromStream() throws IOException, HttpRequest.IllFormedRequest {
         byte[] rawRequest = "GET / HTTP/1.1\r\n\r\n".getBytes();
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawRequest);
         BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));


### PR DESCRIPTION
- remove NULL_METHOD from Method enum
- return 400 Bad Request response if an exception occurs when parsing a request
- return 500 Internal Server Error response if an IOException occurs during a HTTP transaction